### PR TITLE
Make workers process messages concurrently

### DIFF
--- a/src/vumi2/routers.py
+++ b/src/vumi2/routers.py
@@ -2,6 +2,7 @@ import re
 from re import Pattern
 from typing import Dict, List, Tuple
 
+import trio
 from async_amqp.protocol import AmqpProtocol
 from attrs import Factory, define
 
@@ -19,8 +20,13 @@ class ToAddressRouterConfig(BaseConfig):
 class ToAddressRouter(BaseWorker):
     CONFIG_CLASS = ToAddressRouterConfig
 
-    def __init__(self, amqp_connection: AmqpProtocol, config: ToAddressRouterConfig):
-        super().__init__(amqp_connection, config)
+    def __init__(
+        self,
+        nursery: trio.Nursery,
+        amqp_connection: AmqpProtocol,
+        config: ToAddressRouterConfig,
+    ):
+        super().__init__(nursery, amqp_connection, config)
 
     async def setup(self):
         self.mappings: List[Tuple[str, Pattern]] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import trio
 
 from vumi2.amqp import create_amqp_client
 from vumi2.config import load_config
@@ -9,3 +10,10 @@ async def amqp_connection():
     config = load_config()
     async with create_amqp_client(config) as amqp_connection:
         yield amqp_connection
+
+
+@pytest.fixture
+async def nursery():
+    async with trio.open_nursery() as nursery:
+        yield nursery
+        nursery.cancel_scope.cancel()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,7 +58,6 @@ async def test_run_worker():
             "--amqp-hostname",
             "localhost",
         ],
-        run_forever=False,
     )
     assert worker.config.amqp.hostname == "localhost"
 
@@ -93,6 +92,5 @@ def test_main_invalid_worker_class():
 def test_main_valid():
     worker = main(
         args=["worker", "vumi2.workers.BaseWorker", "--amqp-url", "amqp://localhost"],
-        run_forever=False,
     )
     assert worker.config.amqp_url == "amqp://localhost"

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -18,11 +18,11 @@ async def ignore_message(_: MessageType) -> None:
     return
 
 
-async def test_to_addr_router_setup(amqp_connection):
+async def test_to_addr_router_setup(amqp_connection, nursery):
     """
     Sets up all the consumers and publishers according to the config
     """
-    router = ToAddressRouter(amqp_connection, TEST_CONFIG)
+    router = ToAddressRouter(nursery, amqp_connection, TEST_CONFIG)
     await router.setup()
     receive_inbound_connectors = ["test1", "test2"]
     receive_outbound_connectors = ["app1", "app2"]
@@ -34,11 +34,11 @@ async def test_to_addr_router_setup(amqp_connection):
     )
 
 
-async def test_to_addr_router_event(amqp_connection):
+async def test_to_addr_router_event(amqp_connection, nursery):
     """
     Events should be ignored
     """
-    router = ToAddressRouter(amqp_connection, TEST_CONFIG)
+    router = ToAddressRouter(nursery, amqp_connection, TEST_CONFIG)
     await router.setup()
     event = Event(
         user_message_id="1",
@@ -48,11 +48,11 @@ async def test_to_addr_router_event(amqp_connection):
     await router.handle_event(event)
 
 
-async def test_to_addr_router_inbound(amqp_connection):
+async def test_to_addr_router_inbound(amqp_connection, nursery):
     """
     Should be routed according to the to address
     """
-    router = ToAddressRouter(amqp_connection, TEST_CONFIG)
+    router = ToAddressRouter(nursery, amqp_connection, TEST_CONFIG)
     await router.setup()
     msg1 = Message(
         to_addr="12345",
@@ -102,11 +102,11 @@ async def test_to_addr_router_inbound(amqp_connection):
     assert msg2 == received_msg2
 
 
-async def test_to_addr_router_outbound(amqp_connection):
+async def test_to_addr_router_outbound(amqp_connection, nursery):
     """
     Should be routed according to the transport_name
     """
-    router = ToAddressRouter(amqp_connection, TEST_CONFIG)
+    router = ToAddressRouter(nursery, amqp_connection, TEST_CONFIG)
     await router.setup()
     msg1 = Message(
         to_addr="12345",

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -10,15 +10,15 @@ def config():
     return BaseWorker.CONFIG_CLASS.deserialise({})
 
 
-async def test_sentry(amqp_connection, config):
+async def test_sentry(amqp_connection, config, nursery):
     assert sentry_sdk.Hub.current.client is None
 
-    BaseWorker(amqp_connection, config)
+    BaseWorker(nursery, amqp_connection, config)
     assert sentry_sdk.Hub.current.client is None
 
     sentry_dsn = "http://key@example.org/0"
     config.sentry_dsn = sentry_dsn
-    BaseWorker(amqp_connection, config)
+    BaseWorker(nursery, amqp_connection, config)
     client = sentry_sdk.Hub.current.client
     assert client is not None
     assert client.dsn == sentry_dsn


### PR DESCRIPTION
Through some practical testing, it seems like just increasing the prefetch count on the AMQP setup doesn't make the client process multiple messages in parallel.

So what we're doing in this PR, is we create an in-memory channel (with a limited size). Then the callback for receiving a message just puts the message on the queue, and we have N tasks that each take messages off of the queue, and process them concurrently.

In order to do this, we need to pass the trio nursery down the worker -> connector -> consumer chain (we need the nursery to be the parent of these tasks), as well as the concurrency config value so that we know how many tasks to spawn.
