### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_install:
+      - pip install poetry==1.1.12
+      - poetry config virtualenvs.create false
+      - poetry install

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,3 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-python:
-  install:
-    - path: .
-      method: pip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ else:
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions: List[str] = ["sphinx.ext.autodoc"]
+extensions: List[str] = []
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]


### PR DESCRIPTION
Docs builds are currently broken, because the `async-amqp` package is currently at version `0.5.0` on PyPI, but once that package is downloaded and extracted, it reports as being version `0.0.0`. `pip` doesn't like this, but `poetry` handles it fine, so we should rather build our docs using poetry

Built docs can be found here: https://vumi2.readthedocs.io/en/fix-docs-build/index.html
