### PR TITLE
HTTP RPC edge cases

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -39,6 +39,13 @@ worker_concurrency
    The number of messages to prefetch and process in parallel. Defaults to 20.
 sentry_dsn
    The Sentry DSN to use. If specified, errors will be logged to Sentry.
+http_bind
+   Optional. If supplied, runs an HTTP server that binds to `http_bind`. For example, `localhost:8000` to bind to port 8000 on localhost, or `0.0.0.0:80` to bind to port 80 on all interfaces, or `unix:/tmp/socket` to bind to a unix socket. See `the hypercorn documentation`_ for more details. Note that HTTPS is not handled, we recommend using something like `nginx`_ in front of the transport to handle HTTPS.
+log_level
+   The threshold for which messages to log. Defaults to INFO.
+
+.. _the hypercorn documentation: https://pgjones.gitlab.io/hypercorn/how_to_guides/binds.html
+.. _nginx: https://nginx.org/en/docs/
 
 .. _amqp-config:
 

--- a/docs/transports/aat_ussd.rst
+++ b/docs/transports/aat_ussd.rst
@@ -4,6 +4,9 @@ This is a transport for integrating into `AAT`_/`Vodacom messaging`_ USSD HTTP R
 
 It is often used together with the :ref:`to-address-router`, in order for a single USSD code to be shared between applications.
 
+.. note::
+    Because this is an HTTP RPC transport, we need to respond to the inbound HTTP request with the content that we want to send back to the user. This means that the outbound reply message needs to go to the same transport that received the inbound request, so you cannot have multiple instances of this transport with the same `transport_name`.
+
 .. _AAT: https://www.aat.co.za/always-active-mobile/ussd/
 .. _Vodacom messaging: https://www.vodacommessaging.co.za/ussdapi.asp
 

--- a/docs/transports/aat_ussd.rst
+++ b/docs/transports/aat_ussd.rst
@@ -15,19 +15,11 @@ The transport has the following configuration options:
 **Common to all vumi workers**
 
 http_bind
-    Required. This is where the HTTP server will bind. For example, `localhost:8000` to
-    bind to port 8000 on localhost, or `0.0.0.0:80` to bind to port 80 on all
-    interfaces, or `unix:/tmp/socket` to bind to a unix socket. See `the hypercorn documentation`_ for more details. Note that HTTPS is not handled, we recommend using something like
-    `nginx`_ in front of the transport to handle HTTPS.
-amqp
-    Optional. Contains the following keys to connect to the AMQP broker: `hostname`, `port`, `username`, `password`, `vhost`. Defaults to `127.0.0.1` on port `5672` with `guest` as the username and password, and a vhost of `/`.
-amqp_url
-    Optional. A URL to connect to the AMQP broker. If this is set, it will override the `amqp` configuration. For example, `amqp://guest:guest@localhost:5672/%2F`.
+    Required. This is where the HTTP server will bind. For example, `localhost:8000` to bind to port 8000 on localhost, or `0.0.0.0:80` to bind to port 80 on all interfaces, or `unix:/tmp/socket` to bind to a unix socket. See `the hypercorn documentation`_ for more details. Note that HTTPS is not handled, we recommend using something like `nginx`_ in front of the transport to handle HTTPS.
 worker_concurrency
-    Optional. The number of worker tasks to run concurrently. Defaults to 20. This is
-    the maximum amount of concurrent connections allowed.
-sentry_dsn
-    Optional. If set, errors will be reported to Sentry.
+    Optional. The number of worker tasks to run concurrently. Defaults to 20. This is the maximum amount of concurrent connections allowed.
+
+You can find the rest of the base worker configuration at :ref:`base-worker-configuration`
 
 .. _the hypercorn documentation: https://pgjones.gitlab.io/hypercorn/how_to_guides/binds.html
 .. _nginx: https://nginx.org/en/docs/

--- a/src/vumi2/cli.py
+++ b/src/vumi2/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import sys
 from importlib import import_module
 from typing import List, Type
@@ -92,6 +93,7 @@ async def run_worker(worker_cls: Type[BaseWorker], args: List[str]) -> BaseWorke
     parser = build_main_parser(worker_cls=worker_cls)
     parsed_args = parser.parse_args(args=args)
     config = load_config(cls=worker_cls.CONFIG_CLASS, cli=parsed_args)
+    logging.basicConfig(level=config.log_level)
     async with create_amqp_client(config) as amqp_connection:
         async with trio.open_nursery() as nursery:
             worker = worker_cls(

--- a/src/vumi2/config.py
+++ b/src/vumi2/config.py
@@ -24,6 +24,7 @@ class BaseConfig:
     worker_concurrency: int = 20
     sentry_dsn: Optional[str] = None
     http_bind: Optional[str] = None
+    log_level: str = "INFO"
 
     @classmethod
     def deserialise(cls, config: Dict[str, Any]) -> "BaseConfig":

--- a/src/vumi2/transports/aat_ussd/aat_ussd.py
+++ b/src/vumi2/transports/aat_ussd/aat_ussd.py
@@ -77,7 +77,7 @@ class AatUssdTransport(HttpRpcTransport):
             },
             provider=provider,
         )
-        logger.info("Publishing inbound message %s", message)
+        logger.debug("Publishing inbound message %s", message)
         await self.connector.publish_inbound(message)
 
     def generate_body(self, reply: str, callback: str, session_event: Session) -> str:
@@ -106,7 +106,7 @@ class AatUssdTransport(HttpRpcTransport):
         return f"{url}?{query}"
 
     async def handle_outbound_message(self, message: Message) -> None:
-        logger.info("Consuming outbound message %s", message)
+        logger.debug("Consuming outbound message %s", message)
         if not message.in_reply_to:
             logger.info("Outbound message is not a reply, will nack")
             await self.publish_nack(

--- a/src/vumi2/transports/aat_ussd/aat_ussd.py
+++ b/src/vumi2/transports/aat_ussd/aat_ussd.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from logging import getLogger
 from urllib.parse import urlencode, urljoin
 
 from async_amqp import AmqpProtocol
@@ -7,6 +8,8 @@ from trio import Nursery
 
 from vumi2.messages import AddressType, Message, Session, TransportType
 from vumi2.transports.httprpc import HttpRpcConfig, HttpRpcTransport, Request
+
+logger = getLogger(__name__)
 
 
 @define
@@ -35,6 +38,7 @@ class AatUssdTransport(HttpRpcTransport):
         if values.get("to_addr") is None and values.get("request") is None:
             missing_fields.add("request")
         if missing_fields:
+            logger.info("Invalid request, missing fields %s", missing_fields)
             self.finish_request(
                 request_id=message_id,
                 data={"missing_parameter": sorted(missing_fields)},
@@ -55,26 +59,26 @@ class AatUssdTransport(HttpRpcTransport):
             to_addr = values["request"]
             content = None
 
-        await self.connector.publish_inbound(
-            Message(
-                to_addr=to_addr,
-                from_addr=from_addr,
-                transport_name=self.config.transport_name,
-                transport_type=TransportType.USSD,
-                message_id=message_id,
-                session_event=session_event,
-                content=content,
-                from_addr_type=AddressType.MSISDN,
-                helper_metadata={"session_id": ussd_session_id},
-                transport_metadata={
-                    "aat_ussd": {
-                        "provider": provider,
-                        "ussd_session_id": ussd_session_id,
-                    }
-                },
-                provider=provider,
-            )
+        message = Message(
+            to_addr=to_addr,
+            from_addr=from_addr,
+            transport_name=self.config.transport_name,
+            transport_type=TransportType.USSD,
+            message_id=message_id,
+            session_event=session_event,
+            content=content,
+            from_addr_type=AddressType.MSISDN,
+            helper_metadata={"session_id": ussd_session_id},
+            transport_metadata={
+                "aat_ussd": {
+                    "provider": provider,
+                    "ussd_session_id": ussd_session_id,
+                }
+            },
+            provider=provider,
         )
+        logger.info("Publishing inbound message %s", message)
+        await self.connector.publish_inbound(message)
 
     def generate_body(self, reply: str, callback: str, session_event: Session) -> str:
         request = ET.Element("request")
@@ -102,12 +106,15 @@ class AatUssdTransport(HttpRpcTransport):
         return f"{url}?{query}"
 
     async def handle_outbound_message(self, message: Message) -> None:
+        logger.info("Consuming outbound message %s", message)
         if not message.in_reply_to:
+            logger.info("Outbound message is not a reply, will nack")
             await self.publish_nack(
                 message.message_id, "Outbound message is not a reply"
             )
             return
         if not message.content:
+            logger.info("Outbound message has no content, will nack")
             await self.publish_nack(
                 message.message_id, "Outbound message has no content"
             )

--- a/src/vumi2/workers.py
+++ b/src/vumi2/workers.py
@@ -6,6 +6,7 @@ from async_amqp import AmqpProtocol
 from hypercorn import Config as HypercornConfig
 from hypercorn.trio import serve as hypercorn_serve
 from quart_trio import QuartTrio
+from trio import Nursery
 
 from vumi2.config import BaseConfig
 from vumi2.connectors import (
@@ -27,7 +28,7 @@ class BaseWorker:
     CONFIG_CLASS = BaseConfig
 
     def __init__(
-        self, nursery, amqp_connection: AmqpProtocol, config: BaseConfig
+        self, nursery: Nursery, amqp_connection: AmqpProtocol, config: BaseConfig
     ) -> None:
         self.nursery = nursery
         self.connection = amqp_connection

--- a/tests/transports/test_http_rpc.py
+++ b/tests/transports/test_http_rpc.py
@@ -7,7 +7,7 @@ from vumi2.transports import HttpRpcTransport
 
 @pytest.fixture
 def config():
-    return HttpRpcTransport.CONFIG_CLASS(http_bind="localhost")
+    return HttpRpcTransport.CONFIG_CLASS(http_bind="localhost", request_timeout=5)
 
 
 class OkTransport(HttpRpcTransport):
@@ -113,3 +113,24 @@ async def test_missing_request_nack(transport: OkTransport):
     assert event.user_message_id == outbound.message_id
     assert event.sent_message_id == outbound.message_id
     assert event.nack_reason == "No matching request"
+
+
+async def test_timeout(transport: OkTransport, mock_clock):
+    send_channel, receive_channel = open_memory_channel(1)
+
+    async def inbound_consumer(msg):
+        await send_channel.send(msg)
+
+    await transport.setup_receive_inbound_connector(
+        connector_name="http_rpc",
+        inbound_handler=inbound_consumer,
+        event_handler=inbound_consumer,
+    )
+
+    client = transport.http_app.test_client()
+    async with client.request(path="/http_rpc") as connection:
+        await connection.send_complete()
+        await receive_channel.receive()
+        mock_clock.jump(transport.config.request_timeout)
+        response = await connection.as_response()
+        assert response.status_code == 504

--- a/tests/transports/test_http_rpc.py
+++ b/tests/transports/test_http_rpc.py
@@ -1,4 +1,7 @@
+from typing import cast
+
 import pytest
+from quart_trio.testing.connections import TestHTTPConnection as QuartTestHTTPConnection
 from trio import open_memory_channel
 
 from vumi2.messages import EventType, Message, TransportType
@@ -134,3 +137,34 @@ async def test_timeout(transport: OkTransport, mock_clock):
         mock_clock.jump(transport.config.request_timeout)
         response = await connection.as_response()
         assert response.status_code == 504
+    assert transport.requests == {}
+    assert transport.results == {}
+
+
+async def test_client_disconnect(transport: OkTransport):
+    """
+    Transport should clean up so that we don't have memory leaks
+    """
+    send_channel, receive_channel = open_memory_channel(1)
+
+    async def inbound_consumer(msg):
+        await send_channel.send(msg)
+
+    await transport.setup_receive_inbound_connector(
+        connector_name="http_rpc",
+        inbound_handler=inbound_consumer,
+        event_handler=inbound_consumer,
+    )
+
+    client = transport.http_app.test_client()
+    async with client.request(path="/http_rpc") as connection:
+        # cast to get access to _client_send private method
+        connection = cast(QuartTestHTTPConnection, connection)
+        await connection.send_complete()
+        await receive_channel.receive()
+        await connection.disconnect()
+        # It seems like the test client doesn't clean this up properly
+        await connection._client_send.aclose()
+
+    assert transport.requests == {}
+    assert transport.results == {}


### PR DESCRIPTION
This handles some edge cases, namely server side timeouts for long requests, as well as cleanup thereof, and handling cleanup if the client disconnects. It also adds some debug logging in case we need it, and updates the documentation a bit
