### PR TITLE
To address router events

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Welcome to vumi2's documentation!
    config
    routers
    transports
+   message_stores
 
 
 

--- a/docs/message_stores.rst
+++ b/docs/message_stores.rst
@@ -1,0 +1,24 @@
+Message Stores
+==============
+
+A message store will store messages and events to be retrieved at a later stage. Currently it's only being used for the :ref:`to-address-router`, to store outbound messages to reference at a later stage, to route events.
+
+.. _memory-message-store:
+
+Memory Message Store
+--------------------
+
+``vumi2.message_stores.MemoryMessageStore``
+
+This message store stores messages in memory, for a limited amount of time.
+
+Because it's stored in memory, it's not suitable for sharing across different instances, eg. you cannot have multiple router instances to scale up, and use the memory message store.
+
+Messages are only removed on store or fetch, so memory won't be cleared until the next message comes along.
+
+Configuration
+^^^^^^^^^^^^^
+The following configuration options are available:
+
+timeout: int
+    The time, in seconds, to keep messages for. Defaults to 1 hour.

--- a/docs/routers.rst
+++ b/docs/routers.rst
@@ -19,9 +19,6 @@ Outbound messages from applications are routed to the transport that the are in 
 to. The ``transport_name`` field on the message is used to determine which transport
 to send the message to.
 
-.. warning::
-    Transport events are currently not handled by the router, and are discarded.
-
 A good use for this router is on USSD, where for example you have a transport for the
 ``*1234#`` USSD code. Then you can route the base code ``*1234#`` to one application,
 and the ``*1234*1#`` to another.
@@ -37,6 +34,10 @@ transport_names: list[str]
 to_address_mappings: dict[str, str]
     The keys of this dictionary are the application names to send the inbound messages
     to, and the values are the regular expression patterns to match against
+message_store_class: str
+    The path to the class to use for storing messages. Defaults to `vumi2.message_stores.MemoryMessageStore`, a message store that temporarily stores the messages in memory. This transport stores outbound messages in order to know where to route the events for those messages. See :ref:`memory-message-store` for more information
+message_store_config: dict
+    The config for the specified message store.
 
 For example:
 

--- a/src/vumi2/message_stores.py
+++ b/src/vumi2/message_stores.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from typing import Dict, Optional, Protocol, Type
+
+from attrs import define
+from cattrs import structure
+
+from vumi2.messages import Message
+
+
+class MessageStoreConfig(Protocol):  # pragma: no cover
+    @classmethod
+    def deserialise(
+        cls: "Type[MessageStoreConfig]", config: dict
+    ) -> "MessageStoreConfig":
+        ...
+
+
+class MessageStore(Protocol):  # pragma: no cover
+    CONFIG_CLASS: Type[MessageStoreConfig]
+
+    def __init__(self, config: MessageStoreConfig) -> None:
+        ...
+
+    async def store_outbound(self, outbound: Message) -> None:
+        ...
+
+    async def fetch_outbound(self, message_id: str) -> Optional[Message]:
+        ...
+
+
+@define
+class MemoryMessageStoreConfig:
+    timeout: int = 60 * 60
+
+    @classmethod
+    def deserialise(cls, config: dict) -> "MemoryMessageStoreConfig":
+        return structure(config, cls)
+
+
+class MemoryMessageStore:
+    CONFIG_CLASS = MemoryMessageStoreConfig
+
+    def __init__(self, config: MemoryMessageStoreConfig) -> None:
+        self.config = config
+        self.outbounds: Dict[str, Message] = {}
+
+    def _remove_expired(self) -> None:
+        timestamp = datetime.utcnow()
+        expired_outbounds = []
+        for message_id, message in self.outbounds.items():
+            if (timestamp - message.timestamp).total_seconds() >= self.config.timeout:
+                expired_outbounds.append(message_id)
+            else:
+                # Dictionaries are ordered, so we don't need to check all the others
+                # if we've found a new enough message
+                break
+        for message_id in expired_outbounds:
+            del self.outbounds[message_id]
+
+    async def store_outbound(self, outbound: Message) -> None:
+        self._remove_expired()
+        self.outbounds[outbound.message_id] = outbound
+
+    async def fetch_outbound(self, message_id: str) -> Optional[Message]:
+        self._remove_expired()
+        return self.outbounds.get(message_id)

--- a/src/vumi2/message_stores.py
+++ b/src/vumi2/message_stores.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-from typing import Dict, Optional, Protocol, Type
+from typing import Dict, Optional, Type
 
 from attrs import define
 from cattrs import structure
+from typing_extensions import Protocol
 
 from vumi2.messages import Message
 

--- a/src/vumi2/routers.py
+++ b/src/vumi2/routers.py
@@ -1,20 +1,27 @@
 import re
+from logging import getLogger
 from re import Pattern
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Type
 
 import trio
 from async_amqp.protocol import AmqpProtocol
 from attrs import Factory, define
 
+from vumi2.cli import class_from_string
 from vumi2.config import BaseConfig
+from vumi2.message_stores import MessageStore, MessageStoreConfig
 from vumi2.messages import Event, Message
 from vumi2.workers import BaseWorker
+
+logger = getLogger(__name__)
 
 
 @define
 class ToAddressRouterConfig(BaseConfig):
     transport_names: List[str] = Factory(list)
     to_address_mappings: Dict[str, str] = Factory(dict)
+    message_store_class: str = "vumi2.message_stores.MemoryMessageStore"
+    message_store_config: dict = Factory(dict)
 
 
 class ToAddressRouter(BaseWorker):
@@ -27,6 +34,13 @@ class ToAddressRouter(BaseWorker):
         config: ToAddressRouterConfig,
     ):
         super().__init__(nursery, amqp_connection, config)
+        message_store_cls: Type[MessageStore] = class_from_string(
+            config.message_store_class
+        )
+        message_store_config: MessageStoreConfig = (
+            message_store_cls.CONFIG_CLASS.deserialise(config.message_store_config)
+        )
+        self.message_store: MessageStore = message_store_cls(message_store_config)
 
     async def setup(self):
         self.mappings: List[Tuple[str, Pattern]] = []
@@ -51,11 +65,17 @@ class ToAddressRouter(BaseWorker):
             if pattern.match(message.to_addr):
                 await self.receive_outbound_connectors[name].publish_inbound(message)
 
-    async def handle_event(self, _: Event):
-        # Explicitly ignore events
-        return
+    async def handle_event(self, event: Event):
+        outbound = await self.message_store.fetch_outbound(event.user_message_id)
+        if outbound is None:
+            logger.debug("Cannot find outbound for event %s, not routing", event)
+            return
+        for name, pattern in self.mappings:
+            if pattern.match(outbound.from_addr):
+                await self.receive_outbound_connectors[name].publish_event(event)
 
     async def handle_outbound_message(self, message: Message):
+        await self.message_store.store_outbound(message)
         await self.receive_inbound_connectors[message.transport_name].publish_outbound(
             message
         )

--- a/tests/test_message_stores.py
+++ b/tests/test_message_stores.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from vumi2.message_stores import MemoryMessageStore, MemoryMessageStoreConfig
+from vumi2.messages import Message, TransportType
+
+
+@pytest.fixture
+def memory_message_store():
+    config = MemoryMessageStoreConfig.deserialise({})
+    return MemoryMessageStore(config)
+
+
+def create_outbound(timestamp: datetime) -> Message:
+    return Message(
+        to_addr="+27820001001",
+        from_addr="12345",
+        transport_name="bulk_sms",
+        transport_type=TransportType.SMS,
+        timestamp=timestamp,
+    )
+
+
+async def test_memory_store_and_fetch(memory_message_store: MemoryMessageStore):
+    outbound = create_outbound(datetime.utcnow())
+    await memory_message_store.store_outbound(outbound)
+    returned_outbound = await memory_message_store.fetch_outbound(outbound.message_id)
+    assert outbound == returned_outbound
+
+
+async def test_memory_timeout(memory_message_store: MemoryMessageStore):
+    expired_outbound = create_outbound(
+        datetime.utcnow() - timedelta(seconds=memory_message_store.config.timeout + 1)
+    )
+    keep_outbound = create_outbound(datetime.utcnow())
+
+    await memory_message_store.store_outbound(expired_outbound)
+    await memory_message_store.store_outbound(keep_outbound)
+
+    assert (
+        await memory_message_store.fetch_outbound(expired_outbound.message_id) is None
+    )
+    assert (
+        await memory_message_store.fetch_outbound(keep_outbound.message_id)
+        == keep_outbound
+    )


### PR DESCRIPTION
Currently we're not routing events on the to address router, because we require the outbound that the event is for to know where to route the event.

So I've added the a message store, currently only an in memory implementation, but it is pluggable, that will allow us to store messages and retrieve them later, which we can then use to route events.

This memory store stores messages for a limited amount of time.
