### PR TITLE
SMPP outbound messaging

### DIFF
--- a/docs/transports/smpp.rst
+++ b/docs/transports/smpp.rst
@@ -29,6 +29,14 @@ address_range (str)
     Identifies the address or range of addresses served by this client to the server. Maximum length of 40 characters, must be ASCII. Defaults to no address range.
 smpp_enquire_link_interval (int)
     The amount of time, in seconds, between EnquireLink calls. These calls are to ensure that the communication channel between the client and server is still healthly. Defaults to 55 seconds.
+sequencer_class (str)
+    The python path to the class to use for sequencing. The sequencer is responsible for providing the sequence numbers for PDUs. These start at 1 and end at 0x7FFFFFFF, after which the sequencer should roll over to 1 again. The sequencer numbers are used to link responses from the ESME to the original request, so it's important that a sequence number isn't reused while we're still waiting for a response for it. Defaults to `vumi2.transports.smpp.sequencers.InMemorySequencer`, which stores the current sequence position in memory. This is not suitable if you have multiple processes connecting to the same ESME, as the memory is not shared, so the sequencer will not be shared, leading to the same sequence number being used in different processes, which will create overlaps. See :ref:`sequencers` for a list of available sequencers
+sequencer_config (dict)
+    The config that the `sequencer_class` requires. See :ref:`sequencers` for what configuration is required for the sequencer classes.
+submit_sm_processor_class (str)
+    The python path to the class used for generating submit short message (outbound message) requests. This class is responsible for taking an outbound vumi message, and returning a list of PDUs that represents that message, that can be sent to the ESME if we want to send that outbound message. Defaults to `vumi2.transports.smpp.processors.SubmitShortMessageProcessor`, which provides default short message processing that should be usable across a majority of ESMEs. See :ref:`submit-short-message-processors` for a list of submit short message processors that are available.
+submit_sm_processor_config (dict)
+    The config that `submit_sm_processor_class` requires. See :ref:`submit-short-message-processors` for what configuration is required for the various short message processor classes.
 
 
 How it works
@@ -39,13 +47,76 @@ Once connected, it sends a bind transceiver command, with the configured `system
 
 Once it has bound, it sends an enquire link request, at the interval specified by `smpp_enquire_link_interval`, to ensure that the connection is still alive.
 
+.. _sequencers:
+
+Sequencers
+^^^^^^^^^^
+Sequencers are responsible for providing sequence numbers for PDUs. SMPP messages are sent asynchronously, so replies are not necessarily in the same order that the requests were sent in. These sequence numbers are used to match replies from the ESME to the requests that we send them, so it's important that each request that we're waiting on a reply for has a unique sequence number.
+
+These numbers range between 1 and 0x7FFFFFFF.
+
+In-memory sequencer
+"""""""""""""""""""
+`vumi2.transports.smpp.sequencers.InMemorySequencer`
+
+This sequencer stores the current sequence position in memory. It is provided for simple single-process setups, as well as for easy testing. It has no external requirements.
+
+It is not suitable for cases where the sequence number generator needs to be shared across processes, or if the sequence position needs to be persisited across process restarts.
+
+When it reaches 0x7FFFFFFF, it rolls over back to 1, assuming that the lower sequence numbers have been responded to already.
+
+It has no configuration, any configuration fields passed to it will be ignored.
+
+.. _submit-short-message-processors:
+
+Submit Short Message Processors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The job of the submit short message processor is to take outbound vumi messages, and convert them into equivalent PDUs to be sent to the ESME, in order to send the outbound message.
+
+Default submit short message processor
+""""""""""""""""""""""""""""""""""""""
+`vumi2.transports.smpp.processors.SubmitShortMessageProcessor`
+
+This sequencer is designed to work with most EMSEs.
+
+It has the following configuration fields:
+
+.. warning::
+    These fields will be changed, to something better, and then documentation can be improved showing all the choices for each field.
+
+data_coding (int)
+    What data encoding to use. This sets both the `data_coding` field on the PDU, as well as sets the encoding that we use for the message body. The following encodings are supported: SMSC default (GSM03.38), ASCII, Latin 1, JIS (ISO 2022 JP), Cyrllic (ISO-8859-5), Latin/Hebrew (ISO-8859-8), UCS2
+multipart_handling (str)
+    How to handle splitting messages. Defaults to `short_message`, which does not allow long messages. Other options are not yet implemented, but they will be `message_payload`, `multipart_sar`, `multipart_udh`
+service_type (str)
+    Defaults to none. ESME specific, what string to put in the `service_type` field of the PDU.
+source_addr_ton (int)
+    Defaults to unknown. The type of number for the source address (the address of the service).
+source_addr_npi (int)
+    Defaults to unknown. The numbering plan indicator for the source address (the address of the service)
+dest_addr_ton (int)
+    Defaults to unknown. The type of number for the destination address (the address of the user).
+dest_addr_npi (int)
+    Defaults to ISDN. The numbering plan indicator for the destination address (the address of the user)
+registered_delivery (dict)
+    The configuration for registered delivery. Takes the following fields:
+
+    delivery_receipt (int)
+        Defaults to no receipt requested. The SMSC delivery receipt to request
+    sme_originated_acks (list[int])
+        Defaults to none. Which SME originated acknowledgements to request
+    intermediate_notification (bool)
+        Defaults to False. Whether or not to request intermediate notifications
+
+
 
 Still to do
 ^^^^^^^^^^^
 The transport is not yet complete, the following things need to still be done
 
 - Support receiver and transmitter binds, not just transceiver.
-- Support sending outbound messages
+- Better config for processors
+- Outbound messages: support multipart and USSD
 - Support inbound SMPP commands for inbound messages and delivery reports
 - Support all other SMPP inbound commands
 - Timeout for binding

--- a/src/vumi2/transports/smpp/client.py
+++ b/src/vumi2/transports/smpp/client.py
@@ -14,7 +14,8 @@ from trio import (
     sleep_until,
 )
 
-from ...messages import Message
+from vumi2.messages import Message
+
 from .processors import SubmitShortMessageProcesserBase
 from .sequencers import Sequencer
 

--- a/src/vumi2/transports/smpp/codecs.py
+++ b/src/vumi2/transports/smpp/codecs.py
@@ -1,0 +1,96 @@
+import codecs
+from typing import Tuple
+
+GSM0338_CHARSET = (
+    "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1bÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJK"
+    "LMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà"
+)
+GSM0338_CHARSET_MAP = {c: i for i, c in enumerate(GSM0338_CHARSET)}
+GSM0338_CHARSET_EXTENSION = (
+    "````````````````````^```````````````````{}`````\\````````````[~]`|````````````````"
+    "````````````````````€``````````````````````````"
+)
+GSM0338_CHARSET_EXTENSION_MAP = {c: i for i, c in enumerate(GSM0338_CHARSET_EXTENSION)}
+GSM0338_CHARSET_EXTENSION_ESCAPE = 27
+
+
+class VumiCodecException(Exception):
+    """
+    For any issues when encoding or decoding using vumi codecs, that aren't handled
+    by built-in python exceptions
+    """
+
+
+class Gsm0338Codec(codecs.Codec):
+    """
+    Codec for https://en.wikipedia.org/wiki/GSM_03.38
+    """
+
+    NAME = "gsm0338"
+
+    def encode(self, text: str, errors: str = "strict") -> Tuple[bytes, int]:
+        """
+        Modified from https://stackoverflow.com/a/2453027
+        """
+        result = []
+        for position, char in enumerate(text):
+            idx = GSM0338_CHARSET_MAP.get(char)
+            if idx is not None:
+                result.append(idx)
+                continue
+            idx = GSM0338_CHARSET_EXTENSION_MAP.get(char)
+            if idx is not None:
+                result.append(GSM0338_CHARSET_EXTENSION_ESCAPE)
+                result.append(idx)
+                continue
+            if errors == "strict":
+                raise UnicodeEncodeError(
+                    self.NAME, char, position, position + 1, repr(text)
+                )
+            elif errors == "ignore":
+                continue
+            elif errors == "replace":
+                result.append(GSM0338_CHARSET_MAP["?"])
+            else:
+                raise VumiCodecException(
+                    f"Invalid errors type {errors} for {self.NAME} codec encode"
+                )
+        return (bytes(result), len(result))
+
+    def decode(self, text: bytes, errors: str = "strict") -> Tuple[str, int]:
+        """
+        Modified from https://stackoverflow.com/a/13131694
+        """
+        res = iter(text)
+        result = []
+        for position, char in enumerate(res):
+            try:
+                if char == GSM0338_CHARSET_EXTENSION_ESCAPE:
+                    char = next(res)
+                    result.append(GSM0338_CHARSET_EXTENSION[char])
+                else:
+                    result.append(GSM0338_CHARSET[char])
+            except IndexError:
+                if errors == "strict":
+                    raise UnicodeDecodeError(
+                        self.NAME, bytes(char), position, position + 1, repr(text)
+                    )
+                elif errors == "ignore":
+                    continue
+                elif errors == "replace":
+                    result.append("�")
+                else:
+                    raise VumiCodecException(
+                        f"Invalid errors type {errors} for {self.NAME} codec decode"
+                    )
+        return ("".join(result), len(result))
+
+
+def register_codecs():
+    gsm0338 = Gsm0338Codec()
+    CODECS = {
+        gsm0338.NAME: codecs.CodecInfo(
+            name=gsm0338.NAME, encode=gsm0338.encode, decode=gsm0338.decode
+        )
+    }
+    codecs.register(CODECS.get)

--- a/src/vumi2/transports/smpp/codecs.py
+++ b/src/vumi2/transports/smpp/codecs.py
@@ -2,13 +2,13 @@ import codecs
 from typing import Tuple
 
 GSM0338_CHARSET = (
-    "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1bÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJK"
-    "LMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà"
+    "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1bÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>?"
+    "¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà"
 )
 GSM0338_CHARSET_MAP = {c: i for i, c in enumerate(GSM0338_CHARSET)}
 GSM0338_CHARSET_EXTENSION = (
-    "````````````````````^```````````````````{}`````\\````````````[~]`|````````````````"
-    "````````````````````€``````````````````````````"
+    "````````````````````^```````````````````{}`````\\````````````[~]`"
+    "|````````````````````````````````````€``````````````````````````"
 )
 GSM0338_CHARSET_EXTENSION_MAP = {c: i for i, c in enumerate(GSM0338_CHARSET_EXTENSION)}
 GSM0338_CHARSET_EXTENSION_ESCAPE = 27

--- a/src/vumi2/transports/smpp/processors.py
+++ b/src/vumi2/transports/smpp/processors.py
@@ -1,0 +1,109 @@
+from enum import Enum
+from typing import List, Optional
+
+import cattrs
+from attrs import Factory, define
+from smpp.pdu.operations import PDU, SubmitSM
+from smpp.pdu.pdu_types import (
+    AddrNpi,
+    AddrTon,
+    DataCoding,
+    DataCodingDefault,
+    RegisteredDelivery,
+    RegisteredDeliveryReceipt,
+    RegisteredDeliverySmeOriginatedAcks,
+)
+
+from ...messages import Message
+from .codecs import register_codecs
+from .sequencers import Sequencer
+
+register_codecs()
+
+
+class DataCodingCodecs(Enum):
+    SMSC_DEFAULT_ALPHABET = "gsm0338"  # SMSC Default Alphabet
+    IA5_ASCII = "ascii"  # IA5 (CCITT T.50)/ASCII (ANSI X3.4)
+    # 0x02: Octet unspecified (8-bit binary)
+    LATIN_1 = "latin1"  # Latin 1 (ISO-8859-1)
+    # 0x04: Octet unspecified (8-bit binary)
+    # http://www.herongyang.com/Unicode/JIS-ISO-2022-JP-Encoding.html
+    JIS = "iso2022_jp"  # JIS (X 0208-1990)
+    CYRILLIC = "iso8859_5"  # Cyrllic (ISO-8859-5)
+    ISO_8859_8 = "iso8859_8"  # Latin/Hebrew (ISO-8859-8)
+    UCS2 = "utf_16_be"  # UCS2 (ISO/IEC-10646)
+    # TODO: Do we need to add support for these? Original vumi didn't
+    # 0x09: Pictogram Encoding
+    # 0x0A: ISO-2022-JP (Music Codes)
+    # 0x0B: reserved
+    # 0x0C: reserved
+    # 0x0D: Extended Kanji JIS(X 0212-1990)
+    # 0x0E: KS C 5601
+    # 0x0F: reserved
+
+
+class MultipartHandling(Enum):
+    short_message = "short_message"
+    # TODO: Implement these multipart strategies
+    message_payload = "message_payload"
+    multipart_sar = "multipart_sar"
+    multipart_udh = "multipart_udh"
+
+
+@define
+class RegisteredDeliveryConfig:
+    delivery_receipt: RegisteredDeliveryReceipt = (
+        RegisteredDeliveryReceipt.NO_SMSC_DELIVERY_RECEIPT_REQUESTED
+    )
+    sme_originated_acks: List[RegisteredDeliverySmeOriginatedAcks] = Factory(list)
+    intermediate_notification: bool = False
+
+
+@define
+class SubmitShortMessageProcessorConfig:
+    data_coding: DataCodingDefault = DataCodingDefault.SMSC_DEFAULT_ALPHABET
+    multipart_handling: MultipartHandling = MultipartHandling.short_message
+    service_type: Optional[str] = None
+    source_addr_ton: AddrTon = AddrTon.UNKNOWN
+    source_addr_npi: AddrNpi = AddrNpi.UNKNOWN
+    dest_addr_ton: AddrTon = AddrTon.UNKNOWN
+    dest_addr_npi: AddrNpi = AddrNpi.ISDN
+    registered_delivery: RegisteredDeliveryConfig = Factory(RegisteredDeliveryConfig)
+
+
+class SubmitShortMessageProcessor:
+    CONFIG_CLASS = SubmitShortMessageProcessorConfig
+
+    def __init__(self, config: dict, sequencer: Sequencer) -> None:
+        self.sequencer = sequencer
+        self.config = cattrs.structure(config, self.CONFIG_CLASS)
+
+    async def handle_outbound_message(self, message: Message) -> List[PDU]:
+        """
+        Takes an outbound vumi message, and returns the PDUs necessary to send it.
+        """
+        # TODO: support USSD over SMPP
+        codec = DataCodingCodecs[self.config.data_coding.name]
+        short_message = (message.content or "").encode(codec.value)
+
+        registered_delivery = RegisteredDelivery(
+            self.config.registered_delivery.delivery_receipt,
+            self.config.registered_delivery.sme_originated_acks,
+            self.config.registered_delivery.intermediate_notification,
+        )
+
+        return [
+            SubmitSM(
+                seqNum=await self.sequencer.get_next_sequence_number(),
+                service_type=self.config.service_type,
+                source_addr_ton=self.config.source_addr_ton,
+                source_addr_npi=self.config.source_addr_npi,
+                source_addr=message.from_addr,
+                dest_addr_ton=self.config.dest_addr_ton,
+                dest_addr_npi=self.config.dest_addr_npi,
+                destination_addr=message.to_addr,
+                data_coding=DataCoding(schemeData=self.config.data_coding),
+                registered_delivery=registered_delivery,
+                short_message=short_message,
+            )
+        ]

--- a/src/vumi2/transports/smpp/processors.py
+++ b/src/vumi2/transports/smpp/processors.py
@@ -14,7 +14,8 @@ from smpp.pdu.pdu_types import (
     RegisteredDeliverySmeOriginatedAcks,
 )
 
-from ...messages import Message
+from vumi2.messages import Message
+
 from .codecs import register_codecs
 from .sequencers import Sequencer
 

--- a/src/vumi2/transports/smpp/processors.py
+++ b/src/vumi2/transports/smpp/processors.py
@@ -71,6 +71,14 @@ class SubmitShortMessageProcessorConfig:
     registered_delivery: RegisteredDeliveryConfig = Factory(RegisteredDeliveryConfig)
 
 
+class SubmitShortMessageProcesserBase:  # pragma: no cover
+    def __init__(self, config: dict, sequencer: Sequencer) -> None:
+        ...
+
+    async def handle_outbound_message(self, message: Message) -> List[PDU]:
+        ...
+
+
 class SubmitShortMessageProcessor:
     CONFIG_CLASS = SubmitShortMessageProcessorConfig
 

--- a/src/vumi2/transports/smpp/processors.py
+++ b/src/vumi2/transports/smpp/processors.py
@@ -79,7 +79,7 @@ class SubmitShortMessageProcesserBase:  # pragma: no cover
         ...
 
 
-class SubmitShortMessageProcessor:
+class SubmitShortMessageProcessor(SubmitShortMessageProcesserBase):
     CONFIG_CLASS = SubmitShortMessageProcessorConfig
 
     def __init__(self, config: dict, sequencer: Sequencer) -> None:

--- a/src/vumi2/transports/smpp/sequencers.py
+++ b/src/vumi2/transports/smpp/sequencers.py
@@ -1,0 +1,20 @@
+# TODO: Sequencers that can be shared across processes
+
+
+class Sequencer:
+    def __init__(self, config: dict):
+        ...
+
+    async def get_next_sequence_number(self) -> int:
+        ...
+
+
+class InMemorySequencer(Sequencer):
+    def __init__(self, config: dict):
+        self.config = config
+        self.sequence_number = 0
+
+    async def get_next_sequence_number(self) -> int:
+        """The allowed sequence_number range is from 0x00000001 to 0x7FFFFFFF"""
+        self.sequence_number = (self.sequence_number % 0x7FFFFFFF) + 1
+        return self.sequence_number

--- a/src/vumi2/transports/smpp/sequencers.py
+++ b/src/vumi2/transports/smpp/sequencers.py
@@ -1,7 +1,7 @@
 # TODO: Sequencers that can be shared across processes
 
 
-class Sequencer:
+class Sequencer:  # pragma: no cover
     def __init__(self, config: dict):
         ...
 

--- a/src/vumi2/transports/smpp/smpp.py
+++ b/src/vumi2/transports/smpp/smpp.py
@@ -70,5 +70,5 @@ class SmppTransceiverTransport(BaseWorker):
             outbound_handler=self.handle_outbound,
         )
 
-    async def handle_outbound(self, message: Message) -> None:  # pragma: no cover
+    async def handle_outbound(self, message: Message) -> None:
         await self.client.send_vumi_message(message)

--- a/src/vumi2/transports/smpp/smpp.py
+++ b/src/vumi2/transports/smpp/smpp.py
@@ -2,9 +2,10 @@ from logging import getLogger
 from typing import Optional
 
 from async_amqp import AmqpProtocol
-from attrs import define
+from attrs import Factory, define
 from trio import Nursery, open_tcp_stream
 
+from vumi2.cli import class_from_string
 from vumi2.messages import Message
 from vumi2.workers import BaseConfig, BaseWorker
 
@@ -24,6 +25,8 @@ class SmppTransceiverTransportConfig(BaseConfig):
     interface_version: int = 34
     address_range: Optional[str] = None
     smpp_enquire_link_interval: int = 55
+    sequencer_class: str = "vumi2.transports.smpp.sequencers.InMemorySequencer"
+    sequencer_config: dict = Factory(dict)
 
 
 class SmppTransceiverTransport(BaseWorker):
@@ -37,6 +40,8 @@ class SmppTransceiverTransport(BaseWorker):
     ) -> None:
         super().__init__(nursery, amqp_connection, config)
         self.config: SmppTransceiverTransportConfig = config
+        sequencer_class = class_from_string(config.sequencer_class)
+        self.sequencer = sequencer_class(config.sequencer_config)
 
     async def setup(self) -> None:
         # We open the TCP connection first, so that we have a place to send any
@@ -44,7 +49,7 @@ class SmppTransceiverTransport(BaseWorker):
         self.stream = await open_tcp_stream(
             host=self.config.host, port=self.config.port
         )
-        self.client = EsmeClient(self.nursery, self.stream, self.config)
+        self.client = EsmeClient(self.nursery, self.stream, self.config, self.sequencer)
         await self.client.start()
         self.connector = await self.setup_receive_outbound_connector(
             connector_name=self.config.transport_name,

--- a/tests/transports/smpp/test_client.py
+++ b/tests/transports/smpp/test_client.py
@@ -16,6 +16,7 @@ from smpp.pdu.pdu_types import CommandStatus
 from trio.testing import memory_stream_pair
 
 from vumi2.transports.smpp.client import EsmeClient, EsmeResponseStatusError
+from vumi2.transports.smpp.sequencers import InMemorySequencer
 from vumi2.transports.smpp.smpp import SmppTransceiverTransportConfig
 
 
@@ -75,19 +76,7 @@ async def server_stream(stream):
 async def client(nursery, client_stream) -> EsmeClient:
     """An EsmeClient with default config"""
     config = SmppTransceiverTransportConfig()
-    return EsmeClient(nursery, client_stream, config)
-
-
-async def test_get_next_sequence_value(client: EsmeClient):
-    """The allowed sequence_number range is from 0x00000001 to 0x7FFFFFFF"""
-    client.sequence_number = 0
-    assert await client.get_next_sequence_number() == 1
-    assert await client.get_next_sequence_number() == 2
-    assert await client.get_next_sequence_number() == 3
-    # wrap around at 0xFFFFFFFF
-    client.sequence_number = 0x7FFFFFFE
-    assert await client.get_next_sequence_number() == 0x7FFFFFFF
-    assert await client.get_next_sequence_number() == 1
+    return EsmeClient(nursery, client_stream, config, InMemorySequencer({}))
 
 
 async def complete_client_startup(client, server_stream):

--- a/tests/transports/smpp/test_codecs.py
+++ b/tests/transports/smpp/test_codecs.py
@@ -1,0 +1,42 @@
+import pytest
+
+from vumi2.transports.smpp.codecs import VumiCodecException, register_codecs
+
+register_codecs()
+
+
+def test_gsm0338():
+    """
+    Encoding and decoding gsm0338 standard charset should return the correct bytes
+    """
+    assert "HÜLK".encode("gsm0338") == bytes([72, 94, 76, 75])
+    assert bytes([72, 94, 76, 75]).decode("gsm0338") == "HÜLK"
+
+
+def test_gsm0338_extended():
+    """
+    Encoding and decoding gsm0338 extended charset should return the correct bytes
+    """
+    assert "foo €".encode("gsm0338") == bytes([102, 111, 111, 32, 27, 101])
+    assert bytes([102, 111, 111, 32, 27, 101]).decode("gsm0338") == "foo €"
+
+
+def test_gsm0338_errors():
+    """
+    Different error types should result in different actions when encoding and decoding
+    """
+    with pytest.raises(UnicodeEncodeError):
+        "Zoë".encode("gsm0338")
+    with pytest.raises(UnicodeDecodeError):
+        b"Zo\xeb".decode("gsm0338")
+
+    assert "Zoë".encode("gsm0338", errors="replace") == b"Zo?"
+    assert b"Zo\xeb".decode("gsm0338", errors="replace") == "Zo�"
+
+    assert "Zoë".encode("gsm0338", errors="ignore") == b"Zo"
+    assert b"Zo\xeb".decode("gsm0338", errors="ignore") == "Zo"
+
+    with pytest.raises(VumiCodecException):
+        "Zoë".encode("gsm0338", errors="invalid")
+    with pytest.raises(VumiCodecException):
+        b"Zo\xeb".decode("gsm0338", errors="invalid")

--- a/tests/transports/smpp/test_processors.py
+++ b/tests/transports/smpp/test_processors.py
@@ -1,0 +1,111 @@
+import pytest
+from smpp.pdu.pdu_types import (
+    AddrNpi,
+    AddrTon,
+    DataCoding,
+    DataCodingDefault,
+    RegisteredDelivery,
+    RegisteredDeliveryReceipt,
+    RegisteredDeliverySmeOriginatedAcks,
+)
+
+from vumi2.messages import Message, TransportType
+from vumi2.transports.smpp.processors import SubmitShortMessageProcessor
+from vumi2.transports.smpp.sequencers import InMemorySequencer
+
+
+@pytest.fixture
+async def sequencer() -> InMemorySequencer:
+    return InMemorySequencer({})
+
+
+@pytest.fixture
+async def submit_sm_processor(
+    sequencer: InMemorySequencer,
+) -> SubmitShortMessageProcessor:
+    return SubmitShortMessageProcessor({}, sequencer)
+
+
+async def test_submit_sm_outbound_vumi_message(
+    submit_sm_processor: SubmitShortMessageProcessor,
+):
+    """
+    Creates a valid PDU representing the outbound vumi message
+    """
+    message = Message(
+        to_addr="+27820001001",
+        from_addr="12345",
+        transport_name="sms",
+        transport_type=TransportType.SMS,
+        content='Knights who say "Nì!"',
+    )
+    [pdu] = await submit_sm_processor.handle_outbound_message(message)
+    assert pdu.params["source_addr"] == b"12345"
+    assert pdu.params["destination_addr"] == b"+27820001001"
+    assert pdu.params["short_message"] == b'Knights who say "N\x07!"'
+
+
+@pytest.fixture
+async def submit_sm_processor_custom_config(
+    sequencer: InMemorySequencer,
+) -> SubmitShortMessageProcessor:
+    # TODO: Better config than this
+    # Because the PDU library generates Enums that look like:
+    # class AddrTon(Enum):
+    #     UNKNOWN = 1
+    #     INTERNATIONAL = 2
+    #     ...
+    # we have to specify those numbers here when defining config. This makes the config
+    # unclear, but also makes it really easy to make mistakes, since these are all
+    # off-by-one compared to the spec; eg. a data_coding of 1 represents
+    # SMSC_DEFAULT_ALPHABET, which is 0x00 in the SMPP spec
+    return SubmitShortMessageProcessor(
+        {
+            "data_coding": 2,
+            "multipart_handling": "message_payload",
+            "service_type": "test service type",
+            "source_addr_ton": 5,
+            "source_addr_npi": 6,
+            "dest_addr_ton": 2,
+            "dest_addr_npi": 4,
+            "registered_delivery": {
+                "delivery_receipt": 2,
+                "sme_originated_acks": [2],
+                "intermediate_notification": True,
+            },
+        },
+        sequencer,
+    )
+
+
+async def test_submit_sm_outbound_vumi_message_custom_config(
+    submit_sm_processor_custom_config: SubmitShortMessageProcessor,
+):
+    """
+    The custom config should be reflected in the generated PDU
+    """
+    processor = submit_sm_processor_custom_config
+    message = Message(
+        to_addr="+27820001001",
+        from_addr="12345",
+        transport_name="sms",
+        transport_type=TransportType.SMS,
+        content='Knights who say "Ni!"',
+    )
+    [pdu] = await processor.handle_outbound_message(message)
+    assert pdu.params["service_type"] == b"test service type"
+    assert pdu.params["source_addr_ton"] == AddrTon.SUBSCRIBER_NUMBER
+    assert pdu.params["source_addr_npi"] == AddrNpi.NATIONAL
+    assert pdu.params["source_addr"] == b"12345"
+    assert pdu.params["dest_addr_ton"] == AddrTon.INTERNATIONAL
+    assert pdu.params["dest_addr_npi"] == AddrNpi.TELEX
+    assert pdu.params["destination_addr"] == b"+27820001001"
+    assert pdu.params["registered_delivery"] == RegisteredDelivery(
+        RegisteredDeliveryReceipt.SMSC_DELIVERY_RECEIPT_REQUESTED,
+        [RegisteredDeliverySmeOriginatedAcks.SME_MANUAL_ACK_REQUESTED],
+        True,
+    )
+    assert pdu.params["data_coding"] == DataCoding(
+        schemeData=DataCodingDefault.IA5_ASCII
+    )
+    assert pdu.params["short_message"] == b'Knights who say "Ni!"'

--- a/tests/transports/smpp/test_sequencer.py
+++ b/tests/transports/smpp/test_sequencer.py
@@ -1,0 +1,13 @@
+from vumi2.transports.smpp.sequencers import InMemorySequencer
+
+
+async def test_in_memory_sequencer():
+    """The allowed sequence_number range is from 0x00000001 to 0x7FFFFFFF"""
+    sequencer = InMemorySequencer({})
+    assert await sequencer.get_next_sequence_number() == 1
+    assert await sequencer.get_next_sequence_number() == 2
+    assert await sequencer.get_next_sequence_number() == 3
+    # wrap around at 0xFFFFFFFF
+    sequencer.sequence_number = 0x7FFFFFFE
+    assert await sequencer.get_next_sequence_number() == 0x7FFFFFFF
+    assert await sequencer.get_next_sequence_number() == 1


### PR DESCRIPTION
Start of being able to send outbound messages using the SMPP transport.

Handles the basic single part SMSes, in a subset of encodings.

Still need to handle:
- USSD
- Multipart messaging
- Better configuration for processors
