### PR TITLE
Handle other SMPP inbound command PDUs

### DIFF
--- a/docs/transports/smpp.rst
+++ b/docs/transports/smpp.rst
@@ -187,7 +187,6 @@ The transport is not yet complete, the following things need to still be done
 - Support receiver and transmitter binds, not just transceiver.
 - Better config for processors
 - Outbound messages: support USSD
-- Support all other SMPP inbound commands
 - Timeout for binding
 - Timeout for enquire link
 - Sequence number generation is currently just in memory. We might want to have this configurable to store in a place like Redis, to be shared across processes.

--- a/src/vumi2/transports/smpp/client.py
+++ b/src/vumi2/transports/smpp/client.py
@@ -11,6 +11,8 @@ from smpp.pdu.operations import (
     GenericNack,
     PDURequest,
     PDUResponse,
+    Unbind,
+    UnbindResp,
 )
 from smpp.pdu.pdu_encoding import PDUEncoder
 from smpp.pdu.pdu_types import PDU, AddrNpi, AddrTon, CommandStatus
@@ -45,6 +47,10 @@ class EsmeClientError(Exception):
 
 class EsmeResponseStatusError(EsmeClientError):
     """Received a response PDU with non-OK status"""
+
+
+class SmscUnbind(EsmeClientError):
+    """Server has requested unbind"""
 
 
 class EsmeClient:
@@ -270,3 +276,10 @@ class EsmeClient:
             if msg:
                 await self.send_message_channel.send(msg)
         await self.send_pdu(DeliverSMResp(seqNum=pdu.seqNum))
+
+    async def handle_unbind(self, pdu: Unbind):
+        """
+        Server is requesting to unbind, return response and raise error
+        """
+        await self.send_pdu(UnbindResp(seqNum=pdu.seqNum))
+        raise SmscUnbind()

--- a/src/vumi2/transports/smpp/client.py
+++ b/src/vumi2/transports/smpp/client.py
@@ -8,6 +8,7 @@ from smpp.pdu.operations import (
     DeliverSM,
     DeliverSMResp,
     EnquireLink,
+    EnquireLinkResp,
     GenericNack,
     PDURequest,
     PDUResponse,
@@ -283,3 +284,9 @@ class EsmeClient:
         """
         await self.send_pdu(UnbindResp(seqNum=pdu.seqNum))
         raise SmscUnbind()
+
+    async def handle_enquire_link(self, pdu: EnquireLink):
+        """
+        Send back an enquire_link_resp to show that we're still connected
+        """
+        await self.send_pdu(EnquireLinkResp(seqNum=pdu.seqNum))

--- a/tests/transports/smpp/helpers.py
+++ b/tests/transports/smpp/helpers.py
@@ -1,9 +1,10 @@
+from contextlib import asynccontextmanager
 from io import BytesIO
 
 from smpp.pdu.operations import BindTransceiverResp, EnquireLinkResp
 from smpp.pdu.pdu_encoding import PDUEncoder
 from smpp.pdu.pdu_types import PDU
-from trio import serve_tcp
+from trio import open_nursery, serve_tcp
 from trio.testing import memory_stream_pair
 
 
@@ -64,3 +65,12 @@ class TcpFakeSmsc(FakeSmsc):
     async def serve_tcp(self):
         listeners = await self.nursery.start(serve_tcp, self.server, 0)
         self.port = listeners[0].socket.getsockname()[1]
+
+
+@asynccontextmanager
+async def open_autocancel_nursery():
+    async with open_nursery() as nursery:
+        try:
+            yield nursery
+        finally:
+            nursery.cancel_scope.cancel()

--- a/tests/transports/smpp/test_client.py
+++ b/tests/transports/smpp/test_client.py
@@ -1,6 +1,6 @@
 import logging
 
-from pytest import fixture, raises
+import pytest
 from smpp.pdu.operations import (
     BindTransceiver,
     BindTransceiverResp,
@@ -12,6 +12,8 @@ from smpp.pdu.operations import (
     Outbind,
     SubmitSM,
     SubmitSMResp,
+    Unbind,
+    UnbindResp,
 )
 from smpp.pdu.pdu_types import (
     CommandStatus,
@@ -24,7 +26,7 @@ from trio import open_memory_channel
 from trio.testing import memory_stream_pair
 
 from vumi2.messages import DeliveryStatus, Event, EventType, Message, TransportType
-from vumi2.transports.smpp.client import EsmeClient, EsmeResponseStatusError
+from vumi2.transports.smpp.client import EsmeClient, EsmeResponseStatusError, SmscUnbind
 from vumi2.transports.smpp.processors import (
     DeliveryReportProcesser,
     ShortMessageProcessor,
@@ -66,7 +68,7 @@ def test_extract_pdu():
     assert packet_with_extra == bytearray.fromhex("010203")
 
 
-@fixture
+@pytest.fixture
 async def stream():
     """
     A trio memory stream pair. Done as a fixture so that the same stream can easily
@@ -77,59 +79,59 @@ async def stream():
     return (client, server)
 
 
-@fixture
+@pytest.fixture
 async def client_stream(stream):
     """The client part of the trio stream"""
     return stream[0]
 
 
-@fixture
+@pytest.fixture
 async def server_stream(stream):
     """The server part of the trio stream"""
     return stream[1]
 
 
-@fixture
+@pytest.fixture
 async def sequencer():
     return InMemorySequencer({})
 
 
-@fixture
+@pytest.fixture
 async def smpp_cache():
     return InMemorySmppCache({})
 
 
-@fixture
+@pytest.fixture
 async def submit_sm_processor(sequencer):
     return SubmitShortMessageProcessor({}, sequencer)
 
 
-@fixture
+@pytest.fixture
 async def sm_processor(smpp_cache):
     return ShortMessageProcessor({}, smpp_cache)
 
 
-@fixture
+@pytest.fixture
 async def dr_processor(smpp_cache):
     return DeliveryReportProcesser({}, smpp_cache)
 
 
-@fixture
+@pytest.fixture
 async def message_channel():
     return open_memory_channel(1)
 
 
-@fixture
+@pytest.fixture
 async def send_message_channel(message_channel):
     return message_channel[0]
 
 
-@fixture
+@pytest.fixture
 async def receive_message_channel(message_channel):
     return message_channel[1]
 
 
-@fixture
+@pytest.fixture
 async def client(
     nursery,
     client_stream,
@@ -155,7 +157,7 @@ async def client(
     )
 
 
-@fixture
+@pytest.fixture
 async def smsc(server_stream) -> FakeSmsc:
     """A FakeSmsc"""
     return FakeSmsc(server_stream)
@@ -202,7 +204,7 @@ async def test_send_pdu_error_response(client: EsmeClient, smsc: FakeSmsc):
         seqNum=pdu.seqNum, status=CommandStatus.ESME_RX_P_APPN
     )
     await smsc.send_pdu(response_pdu)
-    with raises(EsmeResponseStatusError):
+    with pytest.raises(EsmeResponseStatusError):
         await task
 
 
@@ -217,7 +219,7 @@ async def test_send_pdu_wrong_response(client: EsmeClient, smsc: FakeSmsc):
     task = client.send_pdu(pdu)
 
     await smsc.send_pdu(BindTransceiverResp(seqNum=pdu.seqNum))
-    with raises(EsmeResponseStatusError):
+    with pytest.raises(EsmeResponseStatusError):
         await task
 
 
@@ -389,4 +391,19 @@ async def test_handle_deliver_sm_delivery_report(
 
     resp = await smsc.receive_pdu()
     assert isinstance(resp, DeliverSMResp)
+    assert resp.seqNum == pdu.seqNum
+
+
+@pytest.mark.xfail(raises=SmscUnbind)
+async def test_handle_unbind(client: EsmeClient, smsc: FakeSmsc):
+    """
+    Unbind should respond, then raise an exception
+    """
+    await smsc.start_and_bind(client)
+
+    pdu = Unbind(seqNum=1)
+    await smsc.send_pdu(pdu)
+
+    resp = await smsc.receive_pdu()
+    assert isinstance(resp, UnbindResp)
     assert resp.seqNum == pdu.seqNum

--- a/tests/transports/smpp/test_client.py
+++ b/tests/transports/smpp/test_client.py
@@ -407,3 +407,17 @@ async def test_handle_unbind(client: EsmeClient, smsc: FakeSmsc):
     resp = await smsc.receive_pdu()
     assert isinstance(resp, UnbindResp)
     assert resp.seqNum == pdu.seqNum
+
+
+async def test_handle_enquire_link(client: EsmeClient, smsc: FakeSmsc):
+    """
+    We should send enquire link responses to enquire links
+    """
+    await smsc.start_and_bind(client)
+
+    pdu = EnquireLink(seqNum=1)
+    await smsc.send_pdu(pdu)
+
+    resp = await smsc.receive_pdu()
+    assert isinstance(resp, EnquireLinkResp)
+    assert resp.seqNum == pdu.seqNum

--- a/tests/transports/smpp/test_client.py
+++ b/tests/transports/smpp/test_client.py
@@ -22,7 +22,7 @@ from smpp.pdu.pdu_types import (
     EsmClassMode,
     EsmClassType,
 )
-from trio import open_memory_channel, open_nursery
+from trio import open_memory_channel
 from trio.testing import memory_stream_pair
 
 from vumi2.messages import DeliveryStatus, Event, EventType, Message, TransportType
@@ -36,7 +36,7 @@ from vumi2.transports.smpp.sequencers import InMemorySequencer
 from vumi2.transports.smpp.smpp import SmppTransceiverTransportConfig
 from vumi2.transports.smpp.smpp_cache import InMemorySmppCache
 
-from .helpers import FakeSmsc
+from .helpers import FakeSmsc, open_autocancel_nursery
 
 
 def test_extract_pdu():
@@ -399,7 +399,7 @@ async def test_handle_unbind(client: EsmeClient, smsc: FakeSmsc):
     Unbind should respond, then raise an exception
     """
     with pytest.raises(SmscUnbind):
-        async with open_nursery() as nursery:
+        async with open_autocancel_nursery() as nursery:
             client.nursery = nursery
             await smsc.start_and_bind(client)
 


### PR DESCRIPTION
- Handle unbind
- Send responses to enquire links from the SMSC
- Update docs for added support

We're not handling the following commands:
- `data_sm`: This seems to not be used for SMS or USSD, and also is confusing in the docs. The docs reference that the delivery report should be in the `short_message` field, but there is no `short_message` field for the `data_sm` PDU.
- `outbind`: This only happens if the server connects to us, which we don't support.
- `alert_notification`: We don't use the `data_sm` command, so we shouldn't receive any of these.
- `generic_nack`: we should only get these in response to outbound requests, in which case us waiting and validating responses should catch this.