### PR TITLE
Correctly parse message timestamps with a trailing Z UTC indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+- Correctly parse message timestamps with a trailing Z UTC indicator
 
 ### Changed
 

--- a/src/vumi2/messages.py
+++ b/src/vumi2/messages.py
@@ -11,6 +11,9 @@ VUMI_DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 
 def deserialise_vumi_timestamp(value: str, _: Any) -> datetime:
+    # External systems may give us a timezone-aware UTC timestamp.
+    if value.endswith("Z"):
+        value = value[:-1]
     if "." not in value[-10:]:
         value = f"{value}.0"
     return datetime.strptime(value, VUMI_DATE_FORMAT).replace(tzinfo=UTC)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -167,6 +167,17 @@ def test_vumi_timestamp():
     assert deserialise_vumi_timestamp("2022-05-16 12:13:14", None) == ts
 
 
+def test_deserialise_utc_vumi_timestamp():
+    """
+    If we get a timestamp with a trailing Z UTC timezone indicator, we can
+    deserialise it.
+    """
+    ts = datetime(2022, 5, 16, 12, 13, 14, 123456, tzinfo=UTC)
+    assert deserialise_vumi_timestamp("2022-05-16 12:13:14.123456Z", None) == ts
+    ts = datetime(2022, 5, 16, 12, 13, 14, tzinfo=UTC)
+    assert deserialise_vumi_timestamp("2022-05-16 12:13:14Z", None) == ts
+
+
 def test_generate_message_id():
     """
     Should return hex representation of uuid v4


### PR DESCRIPTION
At least one external system gives us timestamps with a trailing Z to indicate UTC, and it seems like a sensible thing to accept.
