### PR TITLE
Better error handling and reporting when loading worker modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 
 ### Fixed
+- Worker class loading now has better reporting for import-related errors, and no longer masks errors from within the module(s) being imported. (#77, #81)
 
 ## [0.2.2] - 2024-09-25
 

--- a/src/vumi2/cli.py
+++ b/src/vumi2/cli.py
@@ -9,6 +9,7 @@ from attrs import Attribute
 
 from vumi2.amqp import create_amqp_client
 from vumi2.config import BaseConfig, get_config_class, load_config, walk_config_class
+from vumi2.errors import InvalidWorkerClass
 from vumi2.workers import BaseWorker
 
 
@@ -67,12 +68,49 @@ def worker_config_options(
     walk_config_class(cls, add_arg, prefix)
 
 
+def _cfs_err(class_path: str, msg: str) -> InvalidWorkerClass:
+    return InvalidWorkerClass(f"Error loading '{class_path}': {msg}")
+
+
 def class_from_string(class_path: str):
     """
     Given a string path, return the class object.
     """
+    if "." not in class_path:
+        # TODO: Better output for this?
+        raise _cfs_err(class_path, "Invalid worker class")
     module_path, class_name = class_path.rsplit(".", 1)
-    module = import_module(module_path, package=class_name)
+    try:
+        module = import_module(module_path)
+    except ModuleNotFoundError as e:
+        # There's a module we can't find. There are three ways this could happen:
+        #
+        # * The module we're trying to import is missing. This is the common
+        #   case, and we want to report it in a friendly way.
+        #
+        # * A parent of the module we're trying to import is missing. For
+        #   example, we want `foo.bar.baz` but `foo` exists while `foo.bar`
+        #   does not. This is essentially a variant of the above, and we want
+        #   to report it in a similar way.
+        #
+        # * The module we're trying to import is there, but it's trying to
+        #   import something else and that something else is missing. This
+        #   should be handled like any other exception from inside the module
+        #   we're importing, so we reraise.
+
+        if e.name == module_path:
+            # Exact matches are easy.
+            raise _cfs_err(class_path, str(e)) from e
+        if module_path.startswith(e.name) and module_path[len(e.name)] == ".":
+            # e.name must be a module path prefix, not just a string prefix.
+            raise _cfs_err(class_path, str(e)) from e
+        else:
+            # This isn't the module we're trying to import, so reraise.
+            raise
+
+    if not hasattr(module, class_name):
+        raise _cfs_err(class_path, f"No class named '{class_name}'")
+
     return getattr(module, class_name)
 
 
@@ -105,11 +143,11 @@ def main(args=sys.argv[1:]):
     if len(args) >= 2 and args[0] == "worker":
         try:
             worker_cls = class_from_string(class_path=args[1])
-        except (AttributeError, ModuleNotFoundError, ValueError):
+        except InvalidWorkerClass as e:
             # If the second argument is not a valid class, then display an error
             parser.parse_args(args=args)  # If the argument is --help
             parser.print_help()
-            print(f"Invalid worker class: {args[1]}")
+            print(str(e))
             exit(1)
         return trio.run(run_worker, worker_cls, args)
 

--- a/src/vumi2/cli.py
+++ b/src/vumi2/cli.py
@@ -98,10 +98,11 @@ def class_from_string(class_path: str):
         #   should be handled like any other exception from inside the module
         #   we're importing, so we reraise.
 
-        if e.name == module_path:
+        name = str(e.name)  # This is allowed to be None, so stringify it for mypy
+        if name == module_path:
             # Exact matches are easy.
             raise _cfs_err(class_path, str(e)) from e
-        if module_path.startswith(e.name) and module_path[len(e.name)] == ".":
+        if module_path.startswith(name) and module_path[len(name)] == ".":
             # e.name must be a module path prefix, not just a string prefix.
             raise _cfs_err(class_path, str(e)) from e
         else:

--- a/src/vumi2/errors.py
+++ b/src/vumi2/errors.py
@@ -8,3 +8,9 @@ class DuplicateConnectorError(ValueError):
     """
     When adding a connector to a worker that has a connector with the same name
     """
+
+
+class InvalidWorkerClass(VumiError):
+    """
+    TODO
+    """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,11 @@
 import contextlib
+import importlib
 import io
 from argparse import ArgumentParser
+from pathlib import Path
+from textwrap import dedent
 
+import pytest
 from trio import fail_after
 
 from vumi2.cli import (
@@ -87,13 +91,112 @@ def test_main_print_help():
     assert output == help_text.getvalue()
 
 
-def test_main_invalid_worker_class():
-    output = _get_main_command_output(["worker", "invalid"])
-    assert "Invalid worker class" in output
+# TODO: Improve all the above tests to differentiate by behaviour rather than
+# function and to have proper docstrings, etc.
 
 
-# def test_main_valid():
-#     worker = main(
-#         args=["worker", "vumi2.workers.BaseWorker", "--amqp-url", "amqp://localhost"],
-#     )
-#     assert worker.config.amqp_url == "amqp://localhost"
+def test_worker_without_module_and_class():
+    """
+    A valid worker class is a fully qualified Python name for a class. This
+    means we need both a module part and a class part for a name to be valid.
+    """
+
+    # TODO: Better output for this?
+    output = _get_main_command_output(["worker", "module_only"])
+    assert "Error loading 'module_only': Invalid worker class" in output
+
+    output = _get_main_command_output(["worker", "ClassOnly"])
+    assert "Error loading 'ClassOnly': Invalid worker class" in output
+
+
+def _write_python_module(path: Path, body: str):
+    # Remove leading and trailing newlines to account for triple-quotes on
+    # their own lines, then use textwrap.dedent() to remove all shared
+    # indentation.
+    body = dedent(body.strip("\n"))
+    path.write_text(body)
+
+
+def test_worker_module_missing(monkeypatch, tmp_path):
+    """
+    When we try to load a worker class from a module that doesn't exist, we
+    get a suitable error.
+    """
+
+    output = _get_main_command_output(["worker", "nothing_to_see_here.Worker"])
+    assert "Error loading 'nothing_to_see_here.Worker': " in output
+    assert ": No module named 'nothing_to_see_here'" in output
+
+    output = _get_main_command_output(["worker", "ntsh.foo.bar.Worker"])
+    assert "Error loading 'ntsh.foo.bar.Worker': " in output
+    assert ": No module named 'ntsh'" in output
+
+    # Getting a prefix that isn't just the first module requires us to have the
+    # first module available.
+    _write_python_module(tmp_path / "mod_top.py", "")
+
+    monkeypatch.syspath_prepend(tmp_path)
+
+    output = _get_main_command_output(["worker", "mod_top.blah.Worker"])
+    assert "Error loading 'mod_top.blah.Worker': " in output
+    assert ": No module named 'mod_top.blah'" in output
+
+
+def test_worker_class_missing(monkeypatch, tmp_path):
+    """
+    When we try to load a worker class from a module that exist but doesn't
+    contain the worker class, we get a suitable error.
+    """
+    _write_python_module(tmp_path / "mod_noclass.py", "")
+
+    monkeypatch.syspath_prepend(tmp_path)
+
+    output = _get_main_command_output(["worker", "mod_noclass.Worker"])
+    assert "Error loading 'mod_noclass.Worker': " in output
+    assert ": No class named 'Worker'" in output
+
+
+def test_worker_module_with_import_error(monkeypatch, tmp_path):
+    """
+    When we try to load a worker class from a module that exists but has
+    its own import error, that import error is raised as-is instead of being
+    reported as a missing worker class.
+    """
+
+    _write_python_module(tmp_path / "mod_import_err.py", """
+    import something_that_does_not_exist
+    """)
+
+    monkeypatch.syspath_prepend(tmp_path)
+
+    with pytest.raises(ModuleNotFoundError) as e_info:
+        _get_main_command_output(["worker", "mod_import_err.Class"])
+    assert e_info.value.name == "something_that_does_not_exist"
+
+    # In this case, the parent module is trying to import something that's a
+    # string prefix of out module path, but not a path prefix. It's still a bug
+    # in the worker module, so we need to make sure we detect it as one.
+    _write_python_module(tmp_path / "mod_import_err2.py", """
+    import mod_import_err2.bl
+    """)
+
+    with pytest.raises(ModuleNotFoundError) as e_info:
+        _get_main_command_output(["worker", "mod_import_err2.blah.Class"])
+    assert e_info.value.name == "mod_import_err2.bl"
+
+
+def test_worker_module_with_other_error(monkeypatch, tmp_path):
+    """
+    When we try to load a worker class from a module that raises some
+    arbitrary exception on import, that exception isn't caught.
+    """
+
+    _write_python_module(tmp_path / "mod_assert_err.py", """
+    assert False, "oops"
+    """)
+
+    monkeypatch.syspath_prepend(tmp_path)
+
+    with pytest.raises(AssertionError) as e_info:
+        _get_main_command_output(["worker", "mod_assert_err.Class"])
+    assert e_info.value.args[0] == "oops"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import contextlib
-import importlib
 import io
 from argparse import ArgumentParser
 from pathlib import Path
@@ -163,9 +162,12 @@ def test_worker_module_with_import_error(monkeypatch, tmp_path):
     reported as a missing worker class.
     """
 
-    _write_python_module(tmp_path / "mod_import_err.py", """
-    import something_that_does_not_exist
-    """)
+    _write_python_module(
+        tmp_path / "mod_import_err.py",
+        """
+        import something_that_does_not_exist
+        """,
+    )
 
     monkeypatch.syspath_prepend(tmp_path)
 
@@ -176,9 +178,12 @@ def test_worker_module_with_import_error(monkeypatch, tmp_path):
     # In this case, the parent module is trying to import something that's a
     # string prefix of out module path, but not a path prefix. It's still a bug
     # in the worker module, so we need to make sure we detect it as one.
-    _write_python_module(tmp_path / "mod_import_err2.py", """
-    import mod_import_err2.bl
-    """)
+    _write_python_module(
+        tmp_path / "mod_import_err2.py",
+        """
+        import mod_import_err2.bl
+        """,
+    )
 
     with pytest.raises(ModuleNotFoundError) as e_info:
         _get_main_command_output(["worker", "mod_import_err2.blah.Class"])
@@ -191,9 +196,12 @@ def test_worker_module_with_other_error(monkeypatch, tmp_path):
     arbitrary exception on import, that exception isn't caught.
     """
 
-    _write_python_module(tmp_path / "mod_assert_err.py", """
-    assert False, "oops"
-    """)
+    _write_python_module(
+        tmp_path / "mod_assert_err.py",
+        """
+        assert False, "oops"
+        """,
+    )
 
     monkeypatch.syspath_prepend(tmp_path)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -175,6 +175,15 @@ def test_worker_module_with_import_error(monkeypatch, tmp_path):
         _get_main_command_output(["worker", "mod_import_err.Class"])
     assert e_info.value.name == "something_that_does_not_exist"
 
+
+def test_worker_module_with_import_error_substring(monkeypatch, tmp_path):
+    """
+    When we try to load a worker class from a module that exists but has
+    its own import error, that import error is raised as-is even if the module
+    being imported is a string prefix (but not a module prefix) of the module
+    we're trying to import.
+    """
+
     # In this case, the parent module is trying to import something that's a
     # string prefix of out module path, but not a path prefix. It's still a bug
     # in the worker module, so we need to make sure we detect it as one.
@@ -184,6 +193,8 @@ def test_worker_module_with_import_error(monkeypatch, tmp_path):
         import mod_import_err2.bl
         """,
     )
+
+    monkeypatch.syspath_prepend(tmp_path)
 
     with pytest.raises(ModuleNotFoundError) as e_info:
         _get_main_command_output(["worker", "mod_import_err2.blah.Class"])


### PR DESCRIPTION
## Purpose
All sorts of different errors are currently lumped together into "Invalid worker class" with much of the information necessary for determining the underlying problem removed. This PR differentiates between different kinds of "invalid worker class" and separates them from errors raised by the module(s) being imported.

Fixes #77

NOTE: To avoid merge conflicts, I'll wait for #78 to be merged and then rebase before I add the changelog entry for this.

#### Checklist
- [X] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
