### PR TITLE
Default message content to 'hi' if empty

### DIFF
--- a/src/vumi2/applications/turn_channels_api/messages.py
+++ b/src/vumi2/applications/turn_channels_api/messages.py
@@ -45,10 +45,7 @@ def turn_inbound_from_msg(message: Message, channel_id: str) -> dict:
         "message": {
             "type": "text",
             "text": {
-                # Default to "hi" if content is empty,
-                # which happens at the start of a USSD session.
-                # Turn doesn't allow empty messages.
-                "body": message.content or "hi",
+                "body": message.content,
             },
             "from": message.from_addr,
             "id": message.message_id,
@@ -77,7 +74,7 @@ def turn_event_from_ev(event: Event, outbound: Message) -> dict:
     * timestamp (str) - The timestamp at which the event occurred.
     * status (dict) - The status of the event. Currently only sent, delivered, and read
       are supported.
-    * recipient_id (str) - The UUID of the message the event is for.
+    * recipient_id (str) - The address the message was sent to.
     """
     ev = {
         "status": {

--- a/src/vumi2/applications/turn_channels_api/messages.py
+++ b/src/vumi2/applications/turn_channels_api/messages.py
@@ -69,7 +69,7 @@ def turn_outbound_from_msg(message: Message) -> dict:
     return {"messages": [{"id": message.message_id}]}
 
 
-def turn_event_from_ev(event: Event, inbound: Message) -> dict:
+def turn_event_from_ev(event: Event, outbound: Message) -> dict:
     """
     From https://whatsapp.turn.io/docs/api/channel_api#sending-outbound-message-status-to-your-channel
 
@@ -84,7 +84,7 @@ def turn_event_from_ev(event: Event, inbound: Message) -> dict:
             "id": event.user_message_id,
             "timestamp": str(int(event.timestamp.timestamp())),
             "status": None,
-            "recipient_id": inbound.to_addr,
+            "recipient_id": outbound.to_addr,
         }
     }
     if event.event_type == EventType.DELIVERY_REPORT:

--- a/src/vumi2/applications/turn_channels_api/messages.py
+++ b/src/vumi2/applications/turn_channels_api/messages.py
@@ -69,7 +69,7 @@ def turn_outbound_from_msg(message: Message) -> dict:
     return {"messages": [{"id": message.message_id}]}
 
 
-def turn_event_from_ev(event: Event) -> dict:
+def turn_event_from_ev(event: Event, inbound: Message) -> dict:
     """
     From https://whatsapp.turn.io/docs/api/channel_api#sending-outbound-message-status-to-your-channel
 
@@ -77,13 +77,14 @@ def turn_event_from_ev(event: Event) -> dict:
     * timestamp (str) - The timestamp at which the event occurred.
     * status (dict) - The status of the event. Currently only sent, delivered, and read
       are supported.
+    * recipient_id (str) - The UUID of the message the event is for.
     """
     ev = {
         "status": {
             "id": event.user_message_id,
             "timestamp": str(int(event.timestamp.timestamp())),
             "status": None,
-            "recipient_id": event.user_message_id,
+            "recipient_id": inbound.to_addr,
         }
     }
     if event.event_type == EventType.DELIVERY_REPORT:

--- a/src/vumi2/applications/turn_channels_api/messages.py
+++ b/src/vumi2/applications/turn_channels_api/messages.py
@@ -45,7 +45,10 @@ def turn_inbound_from_msg(message: Message, channel_id: str) -> dict:
         "message": {
             "type": "text",
             "text": {
-                "body": message.content,
+                # Default to "hi" if content is empty,
+                # which happens at the start of a USSD session.
+                # Turn doesn't allow empty messages.
+                "body": message.content or "hi",
             },
             "from": message.from_addr,
             "id": message.message_id,

--- a/src/vumi2/applications/turn_channels_api/messages.py
+++ b/src/vumi2/applications/turn_channels_api/messages.py
@@ -83,6 +83,7 @@ def turn_event_from_ev(event: Event) -> dict:
             "id": event.user_message_id,
             "timestamp": str(int(event.timestamp.timestamp())),
             "status": None,
+            "recipient_id": event.user_message_id,
         }
     }
     if event.event_type == EventType.DELIVERY_REPORT:

--- a/src/vumi2/applications/turn_channels_api/turn_channels_api.py
+++ b/src/vumi2/applications/turn_channels_api/turn_channels_api.py
@@ -200,7 +200,12 @@ class TurnChannelsApi(BaseWorker):
         """
         logger.debug("Consuming event %s", event)
 
-        ev = turn_event_from_ev(event)
+        inbound = await self.message_cache.fetch_inbound(event.sent_message_id)
+        if inbound is None:
+            logger.info("Cannot find inbound for event %s, not routing", event)
+            raise HttpErrorResponse(404)
+
+        ev = turn_event_from_ev(event, inbound)
 
         headers = {}
 

--- a/src/vumi2/applications/turn_channels_api/turn_channels_api.py
+++ b/src/vumi2/applications/turn_channels_api/turn_channels_api.py
@@ -203,6 +203,7 @@ class TurnChannelsApi(BaseWorker):
         outbound = await self.message_cache.fetch_outbound(event.sent_message_id)
         if outbound is None:
             logger.warning("Cannot find outbound for event %s, not processing", event)
+            return
 
         ev = turn_event_from_ev(event, outbound)
 

--- a/src/vumi2/applications/turn_channels_api/turn_channels_api.py
+++ b/src/vumi2/applications/turn_channels_api/turn_channels_api.py
@@ -272,9 +272,7 @@ class TurnChannelsApi(BaseWorker):
 
     async def _verify_hmac(self, request_data: str) -> None:
         if self.config.turn_hmac_secret:
-            logger.info(
-                f"Verifying HMAC signature with secret: {self.config.turn_hmac_secret}"
-            )
+            logger.info("Verifying HMAC signature")
             h = hmac.new(
                 self.config.turn_hmac_secret.encode(),
                 request_data.encode(),

--- a/src/vumi2/applications/turn_channels_api/turn_channels_api.py
+++ b/src/vumi2/applications/turn_channels_api/turn_channels_api.py
@@ -200,12 +200,13 @@ class TurnChannelsApi(BaseWorker):
         """
         logger.debug("Consuming event %s", event)
 
-        inbound = await self.message_cache.fetch_inbound(event.sent_message_id)
-        if inbound is None:
-            logger.info("Cannot find inbound for event %s, not routing", event)
+        outbound = await self.message_cache.fetch_outbound(event.sent_message_id)
+        if outbound is None:
+            logger.info("Cannot find outbound for event %s, not routing", event)
+            # TODO: Remove this?
             raise HttpErrorResponse(404)
 
-        ev = turn_event_from_ev(event, inbound)
+        ev = turn_event_from_ev(event, outbound)
 
         headers = {}
 
@@ -231,7 +232,7 @@ class TurnChannelsApi(BaseWorker):
     async def http_send_message(self) -> dict[Any, Any]:
         try:
             timeout = self.config.request_timeout
-            msg: Message | None = None
+            outbound_msg: Message | None = None
 
             try:
                 with fail_after(timeout):
@@ -259,14 +260,17 @@ class TurnChannelsApi(BaseWorker):
                     tom = TurnOutboundMessage.deserialise(
                         msg_dict, default_from=self.config.default_from_addr
                     )
-                    msg = await self.build_outbound(tom, inbound)
+                    outbound_msg = await self.build_outbound(tom, inbound)
+                    await self.message_cache.store_outbound(outbound_msg)
 
-                    await self.connector.publish_outbound(msg)
+                    await self.connector.publish_outbound(outbound_msg)
 
-                    rmsg = turn_outbound_from_msg(msg)
+                    rmsg = turn_outbound_from_msg(outbound_msg)
                     return rmsg
             except trio.TooSlowError as e:
-                logger.error(LOG_MSG_HTTP_TIMEOUT, {"timeout": timeout, "message": msg})
+                logger.error(
+                    LOG_MSG_HTTP_TIMEOUT, {"timeout": timeout, "message": outbound_msg}
+                )
                 raise TimeoutError() from e
         except ApiError as e:
             logger.error(

--- a/src/vumi2/applications/turn_channels_api/turn_channels_api.py
+++ b/src/vumi2/applications/turn_channels_api/turn_channels_api.py
@@ -202,9 +202,7 @@ class TurnChannelsApi(BaseWorker):
 
         outbound = await self.message_cache.fetch_outbound(event.sent_message_id)
         if outbound is None:
-            logger.info("Cannot find outbound for event %s, not routing", event)
-            # TODO: Remove this?
-            raise HttpErrorResponse(404)
+            logger.warning("Cannot find outbound for event %s, not processing", event)
 
         ev = turn_event_from_ev(event, outbound)
 

--- a/src/vumi2/applications/turn_channels_api/turn_channels_api.py
+++ b/src/vumi2/applications/turn_channels_api/turn_channels_api.py
@@ -272,7 +272,9 @@ class TurnChannelsApi(BaseWorker):
 
     async def _verify_hmac(self, request_data: str) -> None:
         if self.config.turn_hmac_secret:
-            logger.info("Verifying HMAC signature")
+            logger.info(
+                f"Verifying HMAC signature with secret: {self.config.turn_hmac_secret}"
+            )
             h = hmac.new(
                 self.config.turn_hmac_secret.encode(),
                 request_data.encode(),

--- a/src/vumi2/transports/aat_ussd/aat_ussd.py
+++ b/src/vumi2/transports/aat_ussd/aat_ussd.py
@@ -46,7 +46,10 @@ class AatUssdTransport(HttpRpcTransport):
         else:
             session_event = Session.NEW
             to_addr = values["request"]
-            content = None
+            # Default content to the request value if content is empty,
+            # which happens at the start of a USSD session.
+            # Turn doesn't allow empty messages.
+            content = values["request"]
 
         message = Message(
             to_addr=to_addr,

--- a/tests/applications/test_turn_channels_api.py
+++ b/tests/applications/test_turn_channels_api.py
@@ -270,7 +270,7 @@ async def test_inbound_message_empty_content(worker_factory, http_server):
                 await http_server.send_rsp(RspInfo())
     inbound = await tca_worker.message_cache.fetch_last_inbound_by_from_address("456")
     assert inbound == msg
-    assert req.body_json["message"]["text"]["body"] == "hi"
+    assert req.body_json["message"]["text"]["body"] == ""
     assert req.body_json["contact"]["id"] == "456"
     assert req.body_json["message"]["from"] == "456"
 
@@ -292,7 +292,7 @@ async def test_inbound_message_none_content(worker_factory, http_server):
                 await http_server.send_rsp(RspInfo())
     inbound = await tca_worker.message_cache.fetch_last_inbound_by_from_address("456")
     assert inbound == msg
-    assert req.body_json["message"]["text"]["body"] == "hi"
+    assert req.body_json["message"]["text"]["body"] is None
     assert req.body_json["contact"]["id"] == "456"
     assert req.body_json["message"]["from"] == "456"
 

--- a/tests/applications/test_turn_channels_api.py
+++ b/tests/applications/test_turn_channels_api.py
@@ -400,9 +400,9 @@ async def test_forward_ack_bad_response(tca_worker, http_server, caplog):
     If forwarding an ack results in an HTTP error, the error and event
     are logged.
     """
-    inbound = mkmsg("hello", from_addr="+1234")
-    await tca_worker.message_cache.store_inbound(inbound)
-    ev = mkev("msg-21", EventType.ACK, sent_message_id=inbound.message_id)
+    outbound = mkmsg("hello", from_addr="+1234")
+    await tca_worker.message_cache.store_outbound(outbound)
+    ev = mkev("msg-21", EventType.ACK, sent_message_id=outbound.message_id)
 
     with fail_after(2):
         async with handle_event(tca_worker, ev):
@@ -420,14 +420,14 @@ async def test_forward_ack_too_slow(worker_factory, http_server, caplog):
     Using an autojump clock here seems to break the AMQP client, so we
     have to use wall-clock time instead.
     """
-    inbound = mkmsg("hello", from_addr="+1234")
+    outbound = mkmsg("hello", from_addr="+1234")
 
     config = mk_config(http_server, event_url_timeout=0.2)
 
     async with worker_factory.with_cleanup(TurnChannelsApi, config) as tca_worker:
         await tca_worker.setup()
-        await tca_worker.message_cache.store_inbound(inbound)
-        ev = mkev("msg-21", EventType.ACK, sent_message_id=inbound.message_id)
+        await tca_worker.message_cache.store_outbound(outbound)
+        ev = mkev("msg-21", EventType.ACK, sent_message_id=outbound.message_id)
         with fail_after(5):
             async with handle_event(tca_worker, ev):
                 await http_server.receive_req()
@@ -442,19 +442,19 @@ async def test_forward_nack(worker_factory, http_server):
     A nack event referencing an outbound message we know about is
     forwarded over HTTP.
     """
-    inbound = mkmsg("hello", from_addr="+1234")
+    outbound = mkmsg("hello", from_addr="+1234")
     ev = mkev(
         "msg-21",
         EventType.NACK,
         nack_reason="KaBooM!",
-        sent_message_id=inbound.message_id,
+        sent_message_id=outbound.message_id,
     )
 
     config = mk_config(http_server)
 
     async with worker_factory.with_cleanup(TurnChannelsApi, config) as tca_worker:
         await tca_worker.setup()
-        await tca_worker.message_cache.store_inbound(inbound)
+        await tca_worker.message_cache.store_outbound(outbound)
         with fail_after(2):
             async with handle_event(tca_worker, ev):
                 req = await http_server.receive_req()
@@ -471,19 +471,19 @@ async def test_forward_dr(worker_factory, http_server):
     A delivery report event referencing an outbound message we know
     about is forwarded over HTTP.
     """
-    inbound = mkmsg("hello", from_addr="+1234")
+    outbound = mkmsg("hello", from_addr="+1234")
     ev = mkev(
         "m-21",
         EventType.DELIVERY_REPORT,
         delivery_status=DeliveryStatus.PENDING,
-        sent_message_id=inbound.message_id,
+        sent_message_id=outbound.message_id,
     )
 
     config = mk_config(http_server)
 
     async with worker_factory.with_cleanup(TurnChannelsApi, config) as tca_worker:
         await tca_worker.setup()
-        await tca_worker.message_cache.store_inbound(inbound)
+        await tca_worker.message_cache.store_outbound(outbound)
         with fail_after(2):
             async with handle_event(tca_worker, ev):
                 req = await http_server.receive_req()

--- a/tests/applications/test_turn_channels_api.py
+++ b/tests/applications/test_turn_channels_api.py
@@ -495,6 +495,31 @@ async def test_forward_dr(worker_factory, http_server):
     assert req.body_json["status"]["id"] == "m-21"
 
 
+async def test_forward_dr_no_outbound(worker_factory, http_server, caplog):
+    """
+    A delivery report event referencing an outbound message we know
+    about is forwarded over HTTP.
+    """
+    outbound = mkmsg("hello", from_addr="+1234")
+    ev = mkev(
+        "m-21",
+        EventType.DELIVERY_REPORT,
+        delivery_status=DeliveryStatus.PENDING,
+        sent_message_id=outbound.message_id,
+    )
+
+    config = mk_config(http_server)
+
+    async with worker_factory.with_cleanup(TurnChannelsApi, config) as tca_worker:
+        await tca_worker.setup()
+        with fail_after(2):
+            async with handle_event(tca_worker, ev):
+                pass
+
+    err = [log for log in caplog.records if log.levelno >= logging.WARNING]
+    assert "Cannot find outbound for event" in err[0].getMessage()
+
+
 async def test_send_outbound(worker_factory, http_server, tca_ro):
     """
     An outbound message received over HTTP is forwarded over AMQP.

--- a/tests/transports/test_aat_ussd.py
+++ b/tests/transports/test_aat_ussd.py
@@ -75,6 +75,7 @@ async def test_inbound_start_session(transport: AatUssdTransport, ri_http_rpc):
         assert inbound.from_addr == "+27820001001"
         assert inbound.provider == "Vodacom"
         assert inbound.session_event == Session.NEW
+        assert inbound.content == "*1234#"
 
         reply = inbound.reply("Test response")
         await ri_http_rpc.publish_outbound(reply)


### PR DESCRIPTION
## Purpose
Turn throws an error if the message content is empty, which happens at the start of a USSD session, so for now we're going to default to "hi"

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)
