### PR TITLE
Error delivery reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.3.3-dev] - UNRELEASED
 ### Added
+- Add handling for failed delivery statuses
 - Message cache for storing inbound messages
 - Link last inbound message to outbound messages for USSD flows
 - Retry messages if Turn rate limits us

--- a/src/vumi2/applications/turn_channels_api/messages.py
+++ b/src/vumi2/applications/turn_channels_api/messages.py
@@ -84,15 +84,19 @@ def turn_event_from_ev(event: Event, outbound: Message) -> dict:
             "recipient_id": outbound.to_addr,
         }
     }
-    if event.event_type == EventType.DELIVERY_REPORT:
-        ev["status"]["status"] = {
-            DeliveryStatus.PENDING: "sent",
-            DeliveryStatus.FAILED: "failed",
-            DeliveryStatus.DELIVERED: "delivered",
-            None: None,
-        }[event.delivery_status]
-    else:
-        ev["status"]["status"] = "sent"
+
+    match event.event_type:
+        case EventType.DELIVERY_REPORT:
+            ev["status"]["status"] = {
+                DeliveryStatus.PENDING: "sent",
+                DeliveryStatus.FAILED: "failed",
+                DeliveryStatus.DELIVERED: "delivered",
+                None: None,
+            }[event.delivery_status]
+        case EventType.NACK:
+            ev["status"]["status"] = "failed"
+        case _:
+            ev["status"]["status"] = "sent"
     return ev
 
 

--- a/src/vumi2/applications/turn_channels_api/messages.py
+++ b/src/vumi2/applications/turn_channels_api/messages.py
@@ -87,8 +87,7 @@ def turn_event_from_ev(event: Event, outbound: Message) -> dict:
     if event.event_type == EventType.DELIVERY_REPORT:
         ev["status"]["status"] = {
             DeliveryStatus.PENDING: "sent",
-            # TODO: Turn doesn't accept a failed status. Log the failure for now?
-            DeliveryStatus.FAILED: "sent",
+            DeliveryStatus.FAILED: "failed",
             DeliveryStatus.DELIVERED: "delivered",
             None: None,
         }[event.delivery_status]


### PR DESCRIPTION
## Purpose
Turn has added `failed` delivery statuses. This adds handling for it to vumi2.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
